### PR TITLE
Use registry names for rovers

### DIFF
--- a/lib/rovex.ex
+++ b/lib/rovex.ex
@@ -6,7 +6,11 @@ defmodule Rover do
   @world_height 100
 
   def start_link({x, y, d, name}) do
-    GenServer.start_link(__MODULE__, {x, y, d, name}, name: String.to_atom(name))
+    GenServer.start_link(
+      __MODULE__,
+      {x, y, d, name},
+      name: RegistryHelper.create_key(name)
+    )
   end
 
   def init({x, y, d, name}) do
@@ -14,7 +18,7 @@ defmodule Rover do
   end
 
   def get_state(name) do
-    GenServer.call(String.to_atom(name), :get_state)
+    GenServer.call(RegistryHelper.create_key(name), :get_state)
   end
 
   def handle_call(:get_state, _from, state) do

--- a/test/rovex_test.exs
+++ b/test/rovex_test.exs
@@ -4,7 +4,14 @@ defmodule RoverTest do
   test "get_state should return current state" do
     {:ok, _} = Rover.start_link({9, 9, :N, "rover0"})
     {:ok, state} = Rover.get_state("rover0")
-    assert state == {9, 9, :N, 0}
+    assert state == {9, 9, :N}
+  end
+
+  test "go_forward should update rover position" do
+    {:ok, _} = Rover.start_link({0, 0, :N, "rover1"})
+    Rover.go_forward("rover1")
+    {:ok, state} = Rover.get_state("rover1")
+    assert state == {0, 1, :N}
   end
 
   test "handle_cast :go_forward should return updated state" do


### PR DESCRIPTION
## Summary
- register rovers in Registry instead of atom names
- fix get_state and add forward movement test

## Testing
- `mix test` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c81f2de8832f85714f91ee7fda9a